### PR TITLE
Add ability to create traffic alarm more than for one NAT Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This module provides settings:
 ```hcl
 
 module "nat_gateway_traffic" {
-  source = "../../terraform/terraform-nat-gateway-traffic-alert"
+  source = "hazelops/nat-gateway-traffic-alert/aws"
   env = var.env
-  name = "nutcorp"
+  name = "<name>"
   natgateway_id = "<NAT Gateway ID>"
   subscription_endpoint = "https://events.pagerduty.com/x-ere/<endpoint>"
 }
@@ -56,7 +56,7 @@ module "nat_gateway_traffic" {
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
 | subscription\_endpoint | Endpoint endpoint for SNS topic subscription, PagerDuty, Slack etc. | `any` | n/a | yes |
 | subscription\_endpoint\_protocol | Endpoint protocol for SNS topic subscription | `string` | `"https"` | no |
-| threshold | The value against which the specified statistic is compared. By default is 1 million bytes.If you use default settings you will be alarmed when throughput will be more than 1 millon byte in 60 seconds | `string` | `"1000000"` | no |
+| threshold | The value against which the specified statistic is compared. By default it is 1 million bytes.If you use default settings you will be alarmed when throughput will be more than 1 millon byte in 60 seconds | `string` | `"1000000"` | no |
 
 ## Outputs
 
@@ -72,4 +72,4 @@ module "nat_gateway_traffic" {
 ### Terraform Module Registry
 
 ![Hazelops logo](https://avatars0.githubusercontent.com/u/63737915?s=25&v=4) [Terraform-nat-gateway-traffic-alert
-](https://registry.terraform.io/modules/hazelops/)
+](https://registry.terraform.io/modules/hazelops/nat-gateway-traffic-alert/aws/latest)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This module provides settings:
 
 module "nat_gateway_traffic" {
   source = "hazelops/nat-gateway-traffic-alert/aws"
+  version = "~> 1.0"
   env = var.env
   name = "<name>"
   natgateway_ids = "[NAT Gateway IDs]>"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "nat_gateway_traffic" {
   source = "hazelops/nat-gateway-traffic-alert/aws"
   env = var.env
   name = "<name>"
-  natgateway_id = "<NAT Gateway ID>"
+  natgateway_ids = "[NAT Gateway IDs]>"
   subscription_endpoint = "https://events.pagerduty.com/x-ere/<endpoint>"
 }
 
@@ -51,7 +51,7 @@ module "nat_gateway_traffic" {
 | env | n/a | `any` | n/a | yes |
 | evaluation\_periods | The number of periods over which data is compared to the specified threshold | `string` | `"1"` | no |
 | name | The name of the monitoring and name of the subscription service endpoint | `any` | n/a | yes |
-| natgateway\_id | id of NAT Gateway | `any` | n/a | yes |
+| natgateway\_ids | ids of NAT Gateways | `any` | n/a | yes |
 | period | The period in seconds over which the specified stat is applied. Period must be 10, 30 or a multiple of 60 | `string` | `"60"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Maximum"` | no |
 | subscription\_endpoint | Endpoint endpoint for SNS topic subscription, PagerDuty, Slack etc. | `any` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,8 @@ resource "aws_sns_topic_subscription" "this" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "output_traffic" {
-  count                     = var.enabled ? 1 : 0
-  alarm_name                = "Output traffic"
+  count                     = var.enabled ? length(var.natgateway_ids) : 0
+  alarm_name                = "Output traffic-${count.index}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = var.evaluation_periods
   metric_name               = "BytesOutToSource"
@@ -22,19 +22,19 @@ resource "aws_cloudwatch_metric_alarm" "output_traffic" {
   period                    = var.period
   statistic                 = var.statistic
   threshold                 = var.threshold
-  alarm_description         = "This metric monitors NAT Gateway output traffic utilization"
+  alarm_description         = "NAT Gateway output traffic utilization is over limit"
   ok_actions                = [aws_sns_topic.this[0].arn]
   alarm_actions             = [aws_sns_topic.this[0].arn]
   insufficient_data_actions = [aws_sns_topic.this[0].arn]
   treat_missing_data        = "notBreaching"
   dimensions = {
-    NatGatewayId = var.natgateway_id
+    NatGatewayId = var.natgateway_ids[count.index]
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "input_traffic" {
-  count                     = var.enabled ? 1 : 0
-  alarm_name                = "Input traffic"
+  count                     = var.enabled ? length(var.natgateway_ids) : 0
+  alarm_name                = "Input traffic-${count.index}"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = var.evaluation_periods
   metric_name               = "BytesInFromSource"
@@ -42,12 +42,12 @@ resource "aws_cloudwatch_metric_alarm" "input_traffic" {
   period                    = var.period
   statistic                 = var.statistic
   threshold                 = var.threshold
-  alarm_description         = "This metric monitors NAT Gateway input traffic utilization"
+  alarm_description         = "NAT Gateway input traffic utilization is over limit"
   ok_actions                = [aws_sns_topic.this[0].arn]
   alarm_actions             = [aws_sns_topic.this[0].arn]
   insufficient_data_actions = [aws_sns_topic.this[0].arn]
   treat_missing_data        = "notBreaching"
   dimensions = {
-    NatGatewayId = var.natgateway_id
+    NatGatewayId = var.natgateway_ids[count.index]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "evaluation_periods" {
 
 variable "threshold" {
   default = "1000000"
-  description = "The value against which the specified statistic is compared. By default is 1 million bytes.If you use default settings you will be alarmed when throughput will be more than 1 millon byte in 60 seconds"
+  description = "The value against which the specified statistic is compared. By default it is 1 million bytes.If you use default settings you will be alarmed when throughput will be more than 1 millon byte in 60 seconds"
 }
 
 variable "statistic" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,6 @@ variable "period" {
   description = "The period in seconds over which the specified stat is applied. Period must be 10, 30 or a multiple of 60"
 }
 
-variable "natgateway_id" {
-  description = "id of NAT Gateway"
+variable "natgateway_ids" {
+  description = "ids of NAT Gateways"
 }


### PR DESCRIPTION
#### What's new: 

 - Add to module ability to create more alarm for more than one AWS NAT Gateway using `count`
 